### PR TITLE
feat(users): add email verification token generation and verification

### DIFF
--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -2,10 +2,13 @@ import { Injectable, BadRequestException, Logger, InternalServerErrorException }
 import { PrismaService } from 'src/prisma/prisma.service';
 import * as argon2 from 'argon2';
 import { CreateUserDto } from 'src/auth/dto/create-user.dto';
+import * as jwt from 'jsonwebtoken';
 
 @Injectable()
 export class UsersService {
   constructor(private readonly prisma: PrismaService) {}
+
+  private readonly secret = process.env.JWT_SECRET ?? 'development';
 
   async create(data: CreateUserDto) {
     // Check if the email is already in use
@@ -34,6 +37,32 @@ export class UsersService {
     } catch (error) {
       Logger.error(error.message, error.stack, UsersService.name);
       throw new BadRequestException('Error creating user');
+    }
+  }
+
+  async generateEmailVerificationToken(email: string) {
+    // Check if the user exists
+    const user = await this.prisma.user.findUnique({
+      where: { email },
+    });
+    if (!user) {
+      Logger.error('User not found', UsersService.name);
+      throw new BadRequestException('User not found');
+    }
+
+    // Generate the token
+    const token = jwt.sign({ email }, this.secret, { expiresIn: '1h' });
+    return token;
+  }
+
+  async verifyEmailVerificationToken(token: string) {
+    try {
+      // Verify the token
+      const decoded = jwt.verify(token, this.secret);
+      return decoded;
+    } catch (error) {
+      Logger.error(error.message, error.stack, UsersService.name);
+      throw new BadRequestException('Invalid token');
     }
   }
 }


### PR DESCRIPTION
This pull request introduces changes to the `src/users/users.service.ts` file, adding functionality for generating and verifying email verification tokens. The most important changes include importing the `jsonwebtoken` library, adding a new secret key for JWT, and implementing methods for token generation and verification.

New functionality for email verification:

* [`src/users/users.service.ts`](diffhunk://#diff-1e863533f2d755cb800597107b0ee786f961f3d439c3392adcb88d670dc66577R5-R12): Imported the `jsonwebtoken` library to handle JWT operations.
* [`src/users/users.service.ts`](diffhunk://#diff-1e863533f2d755cb800597107b0ee786f961f3d439c3392adcb88d670dc66577R5-R12): Added a private `secret` key for JWT, with a fallback to a development key.
* [`src/users/users.service.ts`](diffhunk://#diff-1e863533f2d755cb800597107b0ee786f961f3d439c3392adcb88d670dc66577R42-R67): Implemented the `generateEmailVerificationToken` method to generate a JWT for email verification.
* [`src/users/users.service.ts`](diffhunk://#diff-1e863533f2d755cb800597107b0ee786f961f3d439c3392adcb88d670dc66577R42-R67): Implemented the `verifyEmailVerificationToken` method to verify the JWT and decode the email information.