### PR TITLE
Fetch all books

### DIFF
--- a/src/books/books.service.spec.ts
+++ b/src/books/books.service.spec.ts
@@ -11,6 +11,7 @@ describe('BooksService', () => {
         const prismaMock = {
             book: {
                 create: jest.fn(),
+                findMany: jest.fn(),
             },
         };
 
@@ -59,6 +60,44 @@ describe('BooksService', () => {
                 },
             });
             expect(result).toEqual(createdBook);
+        });
+    });
+
+    describe('findAll', () => {
+        it('should fetch all books from the database', async () => {
+            const books = [
+                {
+                    id: '1',
+                    title: 'Book 1',
+                    author: 'Author 1',
+                    description: 'Description 1',
+                    genre: 'Genre 1',
+                    ISBN: 'ISBN1',
+                    totalCopies: 5,
+                    availableCopies: 5,
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                },
+                {
+                    id: '2',
+                    title: 'Book 2',
+                    author: 'Author 2',
+                    description: 'Description 2',
+                    genre: 'Genre 2',
+                    ISBN: 'ISBN2',
+                    totalCopies: 3,
+                    availableCopies: 3,
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                },
+            ];
+
+            jest.spyOn(prisma.book, 'findMany').mockResolvedValue(books);
+
+            const result = await service.findAll();
+
+            expect(prisma.book.findMany).toHaveBeenCalled();
+            expect(result).toEqual(books);
         });
     });
 });

--- a/src/books/books.service.ts
+++ b/src/books/books.service.ts
@@ -16,8 +16,8 @@ export class BooksService {
         });
     }
 
-    findAll() {
-        return `This action returns all books`;
+    async findAll() {
+        return this.prisma.book.findMany();
     }
 
     findOne(id: number) {


### PR DESCRIPTION
Fixes #83

Update the `findAll` method in `BooksService` to fetch all books from the database using `PrismaService`.

* **BooksService (`src/books/books.service.ts`)**
  - Modify the `findAll` method to use `PrismaService` to fetch all books from the database.

* **BooksService Test (`src/books/books.service.spec.ts`)**
  - Add a test case for the `findAll` method to verify it fetches all books from the database.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Phastboy/library/pull/93?shareId=156ba25a-1b9e-4b6e-bf0d-b784314f30e2).