### PR TITLE
Delete book by ID

### DIFF
--- a/src/books/books.controller.spec.ts
+++ b/src/books/books.controller.spec.ts
@@ -51,7 +51,7 @@ describe('BooksController', () => {
 
             const result = await controller.remove(bookId);
 
-            expect(service.remove).toHaveBeenCalledWith(+bookId);
+            expect(service.remove).toHaveBeenCalledWith(bookId);
             expect(result).toEqual(deletedBook);
         });
     });

--- a/src/books/books.controller.spec.ts
+++ b/src/books/books.controller.spec.ts
@@ -11,6 +11,7 @@ describe('BooksController', () => {
         const prismaMock = {
             book: {
                 create: jest.fn(),
+                delete: jest.fn(),
             },
         };
 
@@ -28,5 +29,30 @@ describe('BooksController', () => {
 
     it('should be defined', () => {
         expect(controller).toBeDefined();
+    });
+
+    describe('remove', () => {
+        it('should delete a book by ID', async () => {
+            const bookId = '1';
+            const deletedBook = {
+                id: bookId,
+                title: 'Test Book',
+                author: 'Test Author',
+                description: 'Test Description',
+                genre: 'Test Genre',
+                ISBN: '1234567890',
+                totalCopies: 5,
+                availableCopies: 5,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            };
+
+            jest.spyOn(service, 'remove').mockResolvedValue(deletedBook);
+
+            const result = await controller.remove(bookId);
+
+            expect(service.remove).toHaveBeenCalledWith(+bookId);
+            expect(result).toEqual(deletedBook);
+        });
     });
 });

--- a/src/books/books.controller.ts
+++ b/src/books/books.controller.ts
@@ -27,16 +27,16 @@ export class BooksController {
 
     @Get(':id')
     findOne(@Param('id') id: string) {
-        return this.booksService.findOne(+id);
+        return this.booksService.findOne(id);
     }
 
     @Patch(':id')
     update(@Param('id') id: string, @Body() updateBookDto: UpdateBookDto) {
-        return this.booksService.update(+id, updateBookDto);
+        return this.booksService.update(id, updateBookDto);
     }
 
     @Delete(':id')
     remove(@Param('id') id: string) {
-        return this.booksService.remove(+id);
+        return this.booksService.remove(id);
     }
 }

--- a/src/books/books.service.spec.ts
+++ b/src/books/books.service.spec.ts
@@ -12,6 +12,7 @@ describe('BooksService', () => {
             book: {
                 create: jest.fn(),
                 findMany: jest.fn(),
+                delete: jest.fn(),
             },
         };
 
@@ -98,6 +99,33 @@ describe('BooksService', () => {
 
             expect(prisma.book.findMany).toHaveBeenCalled();
             expect(result).toEqual(books);
+        });
+    });
+
+    describe('remove', () => {
+        it('should delete a book by ID', async () => {
+            const bookId = '1';
+            const deletedBook = {
+                id: bookId,
+                title: 'Test Book',
+                author: 'Test Author',
+                description: 'Test Description',
+                genre: 'Test Genre',
+                ISBN: '1234567890',
+                totalCopies: 5,
+                availableCopies: 5,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            };
+
+            jest.spyOn(prisma.book, 'delete').mockResolvedValue(deletedBook);
+
+            const result = await service.remove(bookId);
+
+            expect(prisma.book.delete).toHaveBeenCalledWith({
+                where: { id: bookId.toString() },
+            });
+            expect(result).toEqual(deletedBook);
         });
     });
 });

--- a/src/books/books.service.spec.ts
+++ b/src/books/books.service.spec.ts
@@ -104,7 +104,7 @@ describe('BooksService', () => {
 
     describe('remove', () => {
         it('should delete a book by ID', async () => {
-            const bookId = 1;
+            const bookId = '1';
             const deletedBook = {
                 id: bookId,
                 title: 'Test Book',

--- a/src/books/books.service.spec.ts
+++ b/src/books/books.service.spec.ts
@@ -104,7 +104,7 @@ describe('BooksService', () => {
 
     describe('remove', () => {
         it('should delete a book by ID', async () => {
-            const bookId = '1';
+            const bookId = 1;
             const deletedBook = {
                 id: bookId,
                 title: 'Test Book',

--- a/src/books/books.service.ts
+++ b/src/books/books.service.ts
@@ -20,17 +20,17 @@ export class BooksService {
         return this.prisma.book.findMany();
     }
 
-    findOne(id: number) {
+    findOne(id: string) {
         return `This action returns a #${id} book`;
     }
 
-    update(id: number, updateBookDto: UpdateBookDto) {
+    update(id: string, updateBookDto: UpdateBookDto) {
         return `This action updates a #${id} book`;
     }
 
-    async remove(id: number) {
+    async remove(id: string) {
         return this.prisma.book.delete({
-            where: { id: id.toString() },
+            where: { id },
         });
     }
 }

--- a/src/books/books.service.ts
+++ b/src/books/books.service.ts
@@ -28,7 +28,9 @@ export class BooksService {
         return `This action updates a #${id} book`;
     }
 
-    remove(id: number) {
-        return `This action removes a #${id} book`;
+    async remove(id: number) {
+        return this.prisma.book.delete({
+            where: { id: id.toString() },
+        });
     }
 }


### PR DESCRIPTION
Fixes #96

Update the `remove` method in `BooksService` to delete a book by its ID using Prisma.

* **BooksService (`src/books/books.service.ts`)**
  - Update the `remove` method to delete a book by its ID using Prisma and return the deleted book object.

* **BooksController Tests (`src/books/books.controller.spec.ts`)**
  - Add a test for the `remove` method in the `BooksController`.
  - Mock the `remove` method in the `BooksService`.

* **BooksService Tests (`src/books/books.service.spec.ts`)**
  - Add a test for the `remove` method in the `BooksService`.
  - Mock the `delete` method in the `PrismaService`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Phastboy/library/pull/97?shareId=02dffba3-56d0-4c55-98d2-aa0a6be96a17).