### PR TITLE
Revert "Add pagination to list of books"

### DIFF
--- a/src/books/books.controller.spec.ts
+++ b/src/books/books.controller.spec.ts
@@ -81,44 +81,4 @@ describe('BooksController', () => {
             expect(result).toEqual(book);
         });
     });
-
-    describe('findAll', () => {
-        it('should fetch paginated books from the database', async () => {
-            const books = [
-                {
-                    id: '1',
-                    title: 'Book 1',
-                    author: 'Author 1',
-                    description: 'Description 1',
-                    genre: 'Genre 1',
-                    ISBN: 'ISBN1',
-                    totalCopies: 5,
-                    availableCopies: 5,
-                    createdAt: new Date(),
-                    updatedAt: new Date(),
-                },
-                {
-                    id: '2',
-                    title: 'Book 2',
-                    author: 'Author 2',
-                    description: 'Description 2',
-                    genre: 'Genre 2',
-                    ISBN: 'ISBN2',
-                    totalCopies: 3,
-                    availableCopies: 3,
-                    createdAt: new Date(),
-                    updatedAt: new Date(),
-                },
-            ];
-
-            jest.spyOn(service, 'findAll').mockResolvedValue(books);
-
-            const page = 1;
-            const limit = 2;
-            const result = await controller.findAll(page, limit);
-
-            expect(service.findAll).toHaveBeenCalledWith(page, limit);
-            expect(result).toEqual(books);
-        });
-    });
 });

--- a/src/books/books.controller.ts
+++ b/src/books/books.controller.ts
@@ -6,7 +6,6 @@ import {
     Patch,
     Param,
     Delete,
-    Query,
 } from '@nestjs/common';
 import { BooksService } from './books.service';
 import { CreateBookDto } from '../dto/book/create-book.dto';
@@ -22,8 +21,8 @@ export class BooksController {
     }
 
     @Get()
-    findAll(@Query('page') page: number, @Query('limit') limit: number) {
-        return this.booksService.findAll(page, limit);
+    findAll() {
+        return this.booksService.findAll();
     }
 
     @Get(':id')

--- a/src/books/books.service.spec.ts
+++ b/src/books/books.service.spec.ts
@@ -102,47 +102,6 @@ describe('BooksService', () => {
             expect(prisma.book.findMany).toHaveBeenCalled();
             expect(result).toEqual(books);
         });
-
-        it('should fetch paginated books from the database', async () => {
-            const books = [
-                {
-                    id: '1',
-                    title: 'Book 1',
-                    author: 'Author 1',
-                    description: 'Description 1',
-                    genre: 'Genre 1',
-                    ISBN: 'ISBN1',
-                    totalCopies: 5,
-                    availableCopies: 5,
-                    createdAt: new Date(),
-                    updatedAt: new Date(),
-                },
-                {
-                    id: '2',
-                    title: 'Book 2',
-                    author: 'Author 2',
-                    description: 'Description 2',
-                    genre: 'Genre 2',
-                    ISBN: 'ISBN2',
-                    totalCopies: 3,
-                    availableCopies: 3,
-                    createdAt: new Date(),
-                    updatedAt: new Date(),
-                },
-            ];
-
-            jest.spyOn(prisma.book, 'findMany').mockResolvedValue(books);
-
-            const page = 1;
-            const limit = 2;
-            const result = await service.findAll(page, limit);
-
-            expect(prisma.book.findMany).toHaveBeenCalledWith({
-                skip: (page - 1) * limit,
-                take: limit,
-            });
-            expect(result).toEqual(books);
-        });
     });
 
     describe('findOne', () => {

--- a/src/books/books.service.ts
+++ b/src/books/books.service.ts
@@ -16,14 +16,8 @@ export class BooksService {
         });
     }
 
-    async findAll(page: number = 1, limit: number = 10) {
-        const skip = (page - 1) * limit;
-        const take = limit;
-
-        return this.prisma.book.findMany({
-            skip,
-            take,
-        });
+    async findAll() {
+        return this.prisma.book.findMany();
     }
 
     async findOne(id: string) {


### PR DESCRIPTION
This pull request includes several changes to the `BooksController` and `BooksService` classes, primarily focusing on the removal of pagination functionality. The most important changes are the removal of pagination parameters and related tests.

Changes to `BooksController`:

* Removed pagination parameters (`page` and `limit`) from the `findAll` method in `BooksController`.
* Removed the `Query` import from `BooksController` as it is no longer needed.
* Removed the test for the `findAll` method with pagination in `BooksController` test file.

Changes to `BooksService`:

* Removed pagination logic from the `findAll` method in `BooksService`.
* Removed the test for the `findAll` method with pagination in `BooksService` test file.Reverts Phastboy/library#103